### PR TITLE
Add retry flow on generate api key scheduler

### DIFF
--- a/prisma/migrations/20240929091832_add_retry_count_for_job/migration.sql
+++ b/prisma/migrations/20240929091832_add_retry_count_for_job/migration.sql
@@ -1,0 +1,5 @@
+-- AlterEnum
+ALTER TYPE "JobStatus" ADD VALUE 'RETRY';
+
+-- AlterTable
+ALTER TABLE "generate_key_job" ADD COLUMN     "retry_count" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,7 @@ enum PaymentStatus {
 enum JobStatus {
   OPEN
   DONE
+  RETRY
   FAILED
 }
 
@@ -59,12 +60,13 @@ model ApiLog {
 }
 
 model GenerateKeyJob {
-  jobId     Int       @id @default(autoincrement()) @map("job_id")
-  refId     String    @unique @map("ref_id")
-  status    JobStatus @default(OPEN)
-  error     String?   @map("error")
-  createdAt DateTime  @default(now()) @map("created_at")
-  updatedAt DateTime  @default(now()) @updatedAt
+  jobId      Int       @id @default(autoincrement()) @map("job_id")
+  refId      String    @unique @map("ref_id")
+  status     JobStatus @default(OPEN)
+  error      String?   @map("error")
+  retryCount Int       @default(0) @map("retry_count")
+  createdAt  DateTime  @default(now()) @map("created_at")
+  updatedAt  DateTime  @default(now()) @updatedAt
 
   @@index([refId])
   @@map("generate_key_job")


### PR DESCRIPTION
What's new:

- [X] Added retry column to generateKeyJob. It will retry the generate key job when error occurs.
- [X] Added new `JobStatus` with value `RETRY`

> [!IMPORTANT]
> The max retries can be set on environment variable `GENERATE_KEY_MAX_RETRIES`. The default value is 5.